### PR TITLE
Resolve compile issue with recent Eigen version

### DIFF
--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -1,7 +1,7 @@
 include_directories(${PROJECT_SOURCE_DIR})
 
 include_directories(${EIGEN3_INCLUDE_DIR})
-include_directories(${CHOLMOD_INCLUDE_DIR})
+#include_directories(${CHOLMOD_INCLUDE_DIR})
 include_directories(${CSPARSE_INCLUDE_DIR})
 
 
@@ -14,7 +14,7 @@ include(pybind11Tools)
 pybind11_add_module(g2o g2o.cpp)
 target_link_libraries(g2o PRIVATE 
     core
-    solver_cholmod
+    #solver_cholmod
     solver_csparse
     solver_eigen
     solver_dense

--- a/python/core/block_solver.h
+++ b/python/core/block_solver.h
@@ -7,14 +7,14 @@
 #include <g2o/core/solver.h>
 #include <g2o/core/block_solver.h>
 
-#include <g2o/solvers/cholmod/linear_solver_cholmod.h>
+// #include <g2o/solvers/cholmod/linear_solver_cholmod.h>
 #include <g2o/solvers/csparse/linear_solver_csparse.h>
 #include <g2o/solvers/dense/linear_solver_dense.h>
 #include <g2o/solvers/eigen/linear_solver_eigen.h>
 #include <g2o/solvers/pcg/linear_solver_pcg.h>
 
 
-#define _CHOLMOD_FOUND 1
+// #define _CHOLMOD_FOUND 1
 #define _CSPARSE_FOUND 1
 #define _EIGEN_FOUND 1
 

--- a/python/core/eigen_types.h
+++ b/python/core/eigen_types.h
@@ -182,10 +182,10 @@ void declareEigenTypes(py::module & m) {
                 return Eigen::Quaterniond::FromTwoVectors(a, b);
             })
 
-        .def("x", (double (Eigen::Quaterniond::*) () const) &Eigen::Quaterniond::x)
-        .def("y", (double (Eigen::Quaterniond::*) () const) &Eigen::Quaterniond::y)
-        .def("z", (double (Eigen::Quaterniond::*) () const) &Eigen::Quaterniond::z)
-        .def("w", (double (Eigen::Quaterniond::*) () const) &Eigen::Quaterniond::w)
+        .def("x", (const double&  (Eigen::Quaterniond::*) () const) &Eigen::Quaterniond::x)
+        .def("y", (const double&  (Eigen::Quaterniond::*) () const) &Eigen::Quaterniond::y)
+        .def("z", (const double&  (Eigen::Quaterniond::*) () const) &Eigen::Quaterniond::z)
+        .def("w", (const double&  (Eigen::Quaterniond::*) () const) &Eigen::Quaterniond::w)
 
         .def("vec", (const Eigen::VectorBlock<const Eigen::Quaterniond::Coefficients,3> (Eigen::Quaterniond::*) () const) &Eigen::Quaterniond::vec)
 


### PR DESCRIPTION
This fix is necessary to compile g2opy on all platforms,
using recent version of Eigen
see issue at https://github.com/uoip/g2opy/pull/16

original commit message:
Quaterniond::w returns const double & instead of double to work with
Eigen CoeffReturnType